### PR TITLE
Avoids using a STATE attribute as the component name

### DIFF
--- a/injected/src/lib/RootManager.js
+++ b/injected/src/lib/RootManager.js
@@ -118,7 +118,7 @@ class RootManager {
 		return {
 			data: component && component.__DATA_MANAGER_DATA__ ? processDataManagers(component.__DATA_MANAGER_DATA__) : null,
 			id: component[__METAL_DEV_TOOLS_COMPONENT_KEY__],
-			name: component.name || component.constructor.name,
+			name: component.constructor.name
 		};
 	}
 
@@ -253,18 +253,14 @@ class RootManager {
 		return {
 			containsInspected,
 			id: component[__METAL_DEV_TOOLS_COMPONENT_KEY__],
-			name: component.name || component.constructor.name,
+			name: component.constructor.name,
 			childComponents: renderer && renderer.childComponents && renderer.childComponents.map(
 				childComponent => this._traverseTree(childComponent, rootComponent)
 			)
 		};
 	}
 
-	_updateCurrentSelected(id) {
-		if (!id) {
-			id = this._previousSelectedId;
-		}
-
+	_updateCurrentSelected(id = this._previousSelectedId) {
 		if (id) {
 			Messenger.informSelected(
 				this.processComponentObj(this._componentMap[id])

--- a/injected/src/lib/__tests__/RootManager.js
+++ b/injected/src/lib/__tests__/RootManager.js
@@ -166,19 +166,7 @@ describe('RootManager', () => {
 			return {};
 		});
 
-		const component1 = {
-			__DATA_MANAGER_DATA__: {},
-			__METAL_DEV_TOOLS_COMPONENT_KEY__: 'foo1',
-			name: 'Foo1'
-		};
-
-		expect(RootManager.processComponentObj(component1)).toMatchObject({
-			data: {},
-			id: 'foo1',
-			name: 'Foo1'
-		});
-
-		const component2 = {
+		const component = {
 			__DATA_MANAGER_DATA__: {},
 			__METAL_DEV_TOOLS_COMPONENT_KEY__: 'foo2',
 			constructor: {
@@ -186,7 +174,7 @@ describe('RootManager', () => {
 			}
 		};
 
-		expect(RootManager.processComponentObj(component2)).toMatchObject({
+		expect(RootManager.processComponentObj(component)).toMatchObject({
 			data: {},
 			id: 'foo2',
 			name: 'Foo2'
@@ -354,5 +342,26 @@ describe('RootManager', () => {
 
 		expect(RootManager.getDataManagers).toHaveBeenCalledWith(id);
 		expect(spy).toHaveBeenCalledWith({foo: 'bar'});
+	});
+
+	test('should always use the contstructor name instead of a STATE attribute', () => {
+		processDataManagers.mockImplementation(() => {
+			return {};
+		});
+
+		const component = {
+			__DATA_MANAGER_DATA__: {},
+			__METAL_DEV_TOOLS_COMPONENT_KEY__: 'foo2',
+			name: 'foo1',
+			constructor: {
+				name: 'Foo2'
+			}
+		};
+
+		expect(RootManager.processComponentObj(component)).toMatchObject({
+			data: {},
+			id: 'foo2',
+			name: 'Foo2'
+		});
 	});
 });


### PR DESCRIPTION
If you have a component like `Avatar` and it has a `name` attribute, that would display as the name of the component, instead of the constructor's name `Avatar`.