### PR TITLE
Fix circular reference detection

### DIFF
--- a/injected/src/lib/__tests__/cloneObj.js
+++ b/injected/src/lib/__tests__/cloneObj.js
@@ -109,4 +109,26 @@ describe('cloneObj', () => {
 			}
 		);
 	});
+
+	test('should follow redundant-acyclic references', () => {
+		const objD = {name: 'leaf'};
+		const objB = {ref: objD}
+		const objC = {ref: objD}
+		const objA = {left: objB, right: objC}
+
+		expect(cloneObj(objA)).toMatchObject(
+			{
+				left: {
+					ref: {
+						name: 'leaf'
+					}
+				},
+				right: {
+					ref: {
+						name: 'leaf'
+					}
+				}
+			}
+		);
+	});
 });

--- a/injected/src/lib/cloneObj.js
+++ b/injected/src/lib/cloneObj.js
@@ -60,6 +60,8 @@ function cloneObj(objectToBeCloned, visited = new Set()) {
 				objectClone[key] = visited.has(prop) ? '[Circular]' : cloneObj(prop, visited);
 			}
 		}
+
+		visited.delete(objectToBeCloned);
 	}
 
 	return objectClone;


### PR DESCRIPTION
We forgot to remove each node after visit as we recurse back up, which
meant that were detecting references as circular when they were
actually acyclic and only previously visited.